### PR TITLE
Move !draw logic to functions instead of directly accessing .wantsDraw

### DIFF
--- a/plugins/NSFWClasses/CommandHandler.ts
+++ b/plugins/NSFWClasses/CommandHandler.ts
@@ -467,11 +467,11 @@ export class CommandHandler implements ICommandHandler{
                 let fighter:Fighter = receivedData as Fighter;
                 fighter = this.fight.fighterList.getFighterByID(fighter.id)
                 if(fighter) {
-                    if(fighter.wantsDraw){
+                    if(fighter.isRequestingDraw()) {
                         this.fChatLibInstance.sendPrivMessage("[color=red]You are already waiting for the draw.[/color]", data.character);
                     }
                     else{
-                        fighter.wantsDraw = true;
+                        fighter.requestDraw();
                         this.fight.checkForDraw();
                     }
                 }

--- a/plugins/NSFWClasses/Fighter.ts
+++ b/plugins/NSFWClasses/Fighter.ts
@@ -469,6 +469,14 @@ export class Fighter implements IFighter{
         return bondageModCount;
     }
 
+    requestDraw() {
+        this.wantsDraw = true;
+    }
+    
+    isRequestingDraw():boolean {
+        return this.wantsDraw;
+    }
+    
     isCompletelyBound():boolean{
         return this.bondageItemsOnSelf() >= Constants.Fight.Action.Globals.maxBondageItemsOnSelf;
     }


### PR DESCRIPTION
Some when the draw logic needs to be either moved to the database, or less prone to errors from temporary copies.

For now this prevents crudely accessing a property in Fighter.