### PR TITLE
[2.0.0] #35 - properly fix the problem with humiliation damage

### DIFF
--- a/plugins/NSFW.js
+++ b/plugins/NSFW.js
@@ -1265,7 +1265,7 @@ function attackPrepare(actionType, actionId, isSimulation) {
                 minDmg = 1;
                 break;
             case "medium":
-                minDmg = 4;
+                minDmg = 3;
                 break;
             case "heavy":
                 minDmg = 6;
@@ -1293,14 +1293,9 @@ function attackPrepare(actionType, actionId, isSimulation) {
         dmgLust = minDmg;
     }
     else{
+        minDmg += 1;
         dmgHp = Math.floor(minDmg / 2);
         dmgLust = Math.floor(minDmg / 2);
-        if(dmgHp <= 0){
-            dmgHp = 1;
-        }
-        if(dmgLust <= 0){
-            dmgLust = 0;
-        }
     }
 
 


### PR DESCRIPTION
The previous change accidentally set all medium holds to do 4 damage, which makes the scale of 1 -> 4 -> 6 a bit imbalanced.

This solves it by fixing the humiliation stuff directly instead, because I derped.

#35 